### PR TITLE
Minor change to test file

### DIFF
--- a/tests/testthat/test-parameter_id.R
+++ b/tests/testthat/test-parameter_id.R
@@ -74,45 +74,45 @@ pars2 <- c("f1 =~ x2", "f2 =~ c(NA, 1, NA) * x5", "f2 ~ f1")
 pars3 <- c("f1 =~ x2", "f2 =~ c(NA, 1, NA) * x5", "f2 ~ c(1, NA, 1) * f1")
 
 test_that("pars_id: default, where = 'coef'", {
-    expect_true(all(pars_id(pars1, fit_ng) %in%
+    expect_true(setequal(pars_id(pars1, fit_ng),
                     c(1, 3, 7)))
-    expect_true(all(pars_id(pars2, fit_ng) %in%
+    expect_true(setequal(pars_id(pars2, fit_ng),
                     c(1, 7)))
-    expect_true(all(pars_id(pars3, fit_ng) %in%
+    expect_true(setequal(pars_id(pars3, fit_ng),
                     c(1)))
-    expect_true(all(pars_id(pars1, fit_ng_eq) %in%
+    expect_true(setequal(pars_id(pars1, fit_ng_eq),
                     c(1, 3, 7)))
-    expect_true(all(pars_id(pars2, fit_ng_eq) %in%
+    expect_true(setequal(pars_id(pars2, fit_ng_eq),
                     c(1, 7)))
-    expect_true(all(pars_id(pars3, fit_ng_eq) %in%
+    expect_true(setequal(pars_id(pars3, fit_ng_eq),
                     c(1)))
-    expect_true(all(pars_id(pars1, fit_gp) %in%
+    expect_true(setequal(pars_id(pars1, fit_gp),
                     c(1, 3, 7, 30, 32, 36, 59, 61, 65)))
-    expect_true(all(pars_id(pars2, fit_gp) %in%
+    expect_true(setequal(pars_id(pars2, fit_gp),
                     c(1, 3, 7, 30, 36, 59, 61, 65)))
-    expect_true(all(pars_id(pars3, fit_gp) %in%
+    expect_true(setequal(pars_id(pars3, fit_gp),
                     c(1, 3, 30, 36, 59, 61)))
   })
 
 
 test_that("pars_id: where = 'partable'", {
-    expect_true(all(pars_id(pars1, fit_ng, where = "partable") %in%
+    expect_true(setequal(pars_id(pars1, fit_ng, where = "partable"),
                     which(pt_ng$free %in% c(1, 3, 7))))
-    expect_true(all(pars_id(pars2, fit_ng, where = "partable") %in%
+    expect_true(setequal(pars_id(pars2, fit_ng, where = "partable"),
                     which(pt_ng$free %in% c(1, 7))))
-    expect_true(all(pars_id(pars3, fit_ng, where = "partable") %in%
+    expect_true(setequal(pars_id(pars3, fit_ng, where = "partable"),
                     which(pt_ng$free %in% c(1))))
-    expect_true(all(pars_id(pars1, fit_ng_eq, where = "partable")
-                    %in% which(pt_ng_eq$free %in% c(1, 3, 7))))
-    expect_true(all(pars_id(pars2, fit_ng_eq, where = "partable")
-                    %in% which(pt_ng_eq$free %in% c(1, 7))))
-    expect_true(all(pars_id(pars3, fit_ng_eq, where = "partable")
-                    %in% which(pt_ng_eq$free %in% c(1))))
-    expect_true(all(pars_id(pars1, fit_gp, where = "partable") %in%
+    expect_true(setequal(pars_id(pars1, fit_ng_eq, where = "partable"),
+                    which(pt_ng_eq$free %in% c(1, 3, 7))))
+    expect_true(setequal(pars_id(pars2, fit_ng_eq, where = "partable"),
+                    which(pt_ng_eq$free %in% c(1, 7))))
+    expect_true(setequal(pars_id(pars3, fit_ng_eq, where = "partable"),
+                    which(pt_ng_eq$free %in% c(1))))
+    expect_true(setequal(pars_id(pars1, fit_gp, where = "partable"),
                     which(pt_gp$free %in% c(1, 3, 7, 30, 32, 36, 59, 61, 65))))
-    expect_true(all(pars_id(pars2, fit_gp, where = "partable") %in%
+    expect_true(setequal(pars_id(pars2, fit_gp, where = "partable"),
                     which(pt_gp$free %in% c(1, 3, 7, 30, 36, 59, 61, 65))))
-    expect_true(all(pars_id(pars3, fit_gp, where = "partable") %in%
+    expect_true(setequal(pars_id(pars3, fit_gp, where = "partable"),
                     which(pt_gp$free %in% c(1, 3, 30, 36, 59, 61))))
   })
 
@@ -123,44 +123,44 @@ pars2 <- c("f1 =~ x2", "f2 =~ x5.gp2", "f2 ~ f1", "f2 =~ x5.gp3")
 pars3 <- c("f1 =~ x2", "f2 =~ x5.gp2", "f2 =~ x5.gp3", "f2 ~ f1.gp1")
 
 test_that("pars_id_lorg: default, where = 'coef'", {
-    expect_true(all(pars_id_lorg(pars1, fit_ng) %in%
+    expect_true(setequal(pars_id_lorg(pars1, fit_ng),
                     c(1, 3, 7)))
-    expect_true(all(pars_id_lorg(pars2, fit_ng) %in%
+    expect_true(setequal(pars_id_lorg(pars2, fit_ng),
                     c(1, 7)))
-    expect_true(all(pars_id_lorg(pars3, fit_ng) %in%
+    expect_true(setequal(pars_id_lorg(pars3, fit_ng),
                     c(1)))
-    expect_true(all(pars_id_lorg(pars1, fit_ng_eq) %in%
+    expect_true(setequal(pars_id_lorg(pars1, fit_ng_eq),
                     c(1, 3, 7)))
-    expect_true(all(pars_id_lorg(pars2, fit_ng_eq) %in%
+    expect_true(setequal(pars_id_lorg(pars2, fit_ng_eq),
                     c(1, 7)))
-    expect_true(all(pars_id_lorg(pars3, fit_ng_eq) %in%
+    expect_true(setequal(pars_id_lorg(pars3, fit_ng_eq),
                     c(1)))
-    expect_true(all(pars_id_lorg(pars1, fit_gp) %in%
+    expect_true(setequal(pars_id_lorg(pars1, fit_gp),
                     c(1, 3, 7, 30, 32, 36, 59, 61, 65)))
-    expect_true(all(pars_id_lorg(pars2, fit_gp) %in%
+    expect_true(setequal(pars_id_lorg(pars2, fit_gp),
                     c(1, 3, 7, 30, 36, 59, 61, 65)))
-    expect_true(all(pars_id_lorg(pars3, fit_gp) %in%
+    expect_true(setequal(pars_id_lorg(pars3, fit_gp),
                     c(1, 3, 30, 36, 59, 61)))
   })
 
 test_that("pars_id_lorg: where = 'partable'", {
-    expect_true(all(pars_id_lorg(pars1, fit_ng, where = "partable") %in%
+    expect_true(setequal(pars_id_lorg(pars1, fit_ng, where = "partable"),
                     which(pt_ng$free %in% c(1, 3, 7))))
-    expect_true(all(pars_id_lorg(pars2, fit_ng, where = "partable") %in%
+    expect_true(setequal(pars_id_lorg(pars2, fit_ng, where = "partable"),
                     which(pt_ng$free %in% c(1, 7))))
-    expect_true(all(pars_id_lorg(pars3, fit_ng, where = "partable") %in%
+    expect_true(setequal(pars_id_lorg(pars3, fit_ng, where = "partable"),
                     which(pt_ng$free %in% c(1))))
-    expect_true(all(pars_id_lorg(pars1, fit_ng_eq, where = "partable") %in%
+    expect_true(setequal(pars_id_lorg(pars1, fit_ng_eq, where = "partable"),
                     which(pt_ng_eq$free %in% c(1, 3, 7))))
-    expect_true(all(pars_id_lorg(pars2, fit_ng_eq, where = "partable") %in%
+    expect_true(setequal(pars_id_lorg(pars2, fit_ng_eq, where = "partable"),
                     which(pt_ng_eq$free %in% c(1, 7))))
-    expect_true(all(pars_id_lorg(pars3, fit_ng_eq, where = "partable") %in%
+    expect_true(setequal(pars_id_lorg(pars3, fit_ng_eq, where = "partable"),
                     which(pt_ng_eq$free %in% c(1))))
-    expect_true(all(pars_id_lorg(pars1, fit_gp, where = "partable") %in%
+    expect_true(setequal(pars_id_lorg(pars1, fit_gp, where = "partable"),
                     which(pt_gp$free %in% c(1, 3, 7, 30, 32, 36, 59, 61, 65))))
-    expect_true(all(pars_id_lorg(pars2, fit_gp, where = "partable") %in%
+    expect_true(setequal(pars_id_lorg(pars2, fit_gp, where = "partable"),
                     which(pt_gp$free %in% c(1, 3, 7, 30, 36, 59, 61, 65))))
-    expect_true(all(pars_id_lorg(pars3, fit_gp, where = "partable") %in%
+    expect_true(setequal(pars_id_lorg(pars3, fit_gp, where = "partable"),
                     which(pt_gp$free %in% c(1, 3, 30, 36, 59, 61))))
   })
 


### PR DESCRIPTION
Do you think it makes sense to use `setequal(a, b)` instead of `all(a %in% b)` when an exact match is needed? The reason is that if `a` has less elements than `b`, `all(a %in% b)` still returns `TRUE`. 