### PR TITLE
0.1.5.4: Use lavaan::lavCor() instead of norm2::emNorm()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: semfindr
 Title: Influential Cases in Structural Equation Modeling
-Version: 0.1.5.3
+Version: 0.1.5.4
 Authors@R: c(
     person(given = "Shu Fai",
            family = "Cheung",
@@ -31,8 +31,7 @@ Suggests:
     parallel,
     knitr,
     rmarkdown,
-    modi,
-    norm2
+    modi
 Imports:
     lavaan,
     ggplot2,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# semfindr 0.1.5.3
+# semfindr 0.1.5.4
 
 - Fixed typos in the article on
   multiple-group models. (0.1.5.1)
@@ -11,6 +11,12 @@
   option. (0.1.5.2)
 - Fixed an error at CRAN check due to
   suggested packages not installed. (0.1.5.3)
+- Use `lavaan::lavCor()` to estimate
+  means and correlations for Mahalanobis
+  distance when missing data is present.
+  The package `norm2` is no longer
+  needed nor suggested. (0.1.5.4)
+
 
 # semfindr 0.1.5
 

--- a/R/mahalanobis_exo.R
+++ b/R/mahalanobis_exo.R
@@ -12,7 +12,7 @@
 #'
 #' If there are missing values on the observed predictors, the means
 #' and variance-covariance matrices will be estimated by maximum
-#' likelihood using [norm2::emNorm()]. The estimates will be passed
+#' likelihood using [lavaan::lavCor()]. The estimates will be passed
 #' to [modi::MDmiss()] to compute the Mahalanobis distance.
 #'
 #' Supports both single-group and multiple-group models.
@@ -25,10 +25,8 @@
 #' [lavaan::cfa()] and [lavaan::sem()], or the output from
 #' [lavaan_rerun()].
 #'
-#' @param emNorm_arg A list of argument for [norm2::emNorm()].
-#' Default is `list(estimate.worst = FALSE, criterion = 1e-6)`.
-#' Ignored if there is no missing data on the observed
-#' predictors.
+#' @param emNorm_arg No longer used. Kept for backward
+#' compatibility.
 #'
 #' @return A `md_semfindr`-class object, which is
 #' a one-column matrix (a column vector) of the Mahalanobis
@@ -129,10 +127,6 @@ mahalanobis_predictors <- function(fit,
             missing_data <- TRUE
             if (!requireNamespace("modi", quietly = TRUE)) {
                 stop(paste("Missing data is present but the modi package",
-                          "is not installed."))
-              }
-            if (!requireNamespace("norm2", quietly = TRUE)) {
-                stop(paste("Missing data is present but the norm2 package",
                           "is not installed."))
               }
         } else {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![R-CMD-check](https://github.com/sfcheung/semfindr/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/sfcheung/semfindr/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
-(Version 0.1.5.3, updated on 2023-08-29, [release history](https://sfcheung.github.io/semfindr/news/index.html))
+(Version 0.1.5.4, updated on 2023-08-30, [release history](https://sfcheung.github.io/semfindr/news/index.html))
 
 # semfindr: Finding influential cases in SEM <img src="man/figures/logo.png" align="right" height="150" />
 

--- a/man/mahalanobis_predictors.Rd
+++ b/man/mahalanobis_predictors.Rd
@@ -14,10 +14,8 @@ mahalanobis_predictors(
 \code{\link[lavaan:cfa]{lavaan::cfa()}} and \code{\link[lavaan:sem]{lavaan::sem()}}, or the output from
 \code{\link[=lavaan_rerun]{lavaan_rerun()}}.}
 
-\item{emNorm_arg}{A list of argument for \code{\link[norm2:emNorm]{norm2::emNorm()}}.
-Default is \code{list(estimate.worst = FALSE, criterion = 1e-6)}.
-Ignored if there is no missing data on the observed
-predictors.}
+\item{emNorm_arg}{No longer used. Kept for backward
+compatibility.}
 }
 \value{
 A \code{md_semfindr}-class object, which is
@@ -40,7 +38,7 @@ to compute the Mahalanobis distance.
 
 If there are missing values on the observed predictors, the means
 and variance-covariance matrices will be estimated by maximum
-likelihood using \code{\link[norm2:emNorm]{norm2::emNorm()}}. The estimates will be passed
+likelihood using \code{\link[lavaan:lavCor]{lavaan::lavCor()}}. The estimates will be passed
 to \code{\link[modi:MDmiss]{modi::MDmiss()}} to compute the Mahalanobis distance.
 
 Supports both single-group and multiple-group models.

--- a/man/mahalanobis_rerun.Rd
+++ b/man/mahalanobis_rerun.Rd
@@ -14,11 +14,8 @@ mahalanobis_rerun(
 \code{\link[lavaan:cfa]{lavaan::cfa()}} and \code{\link[lavaan:sem]{lavaan::sem()}}, or the output from
 \code{\link[=lavaan_rerun]{lavaan_rerun()}}.}
 
-\item{emNorm_arg}{A list of argument for
-\code{\link[norm2:emNorm]{norm2::emNorm()}}. Default is
-\code{list(estimate.worst = FALSE, criterion = 1e-6)}.
-Ignored if there is no missing data on the exogenous observed
-variables.}
+\item{emNorm_arg}{No longer used. Kept for backward
+compatibility.}
 }
 \value{
 A \code{md_semfindr}-class object, which is
@@ -41,7 +38,7 @@ to compute the Mahalanobis distance.
 
 If there are missing values on the observed predictors, the means
 and variance-covariance matrices will be estimated by maximum
-likelihood using \code{\link[norm2:emNorm]{norm2::emNorm()}}. The estimates will be passed
+likelihood using \code{\link[lavaan:lavCor]{lavaan::lavCor()}}. The estimates will be passed
 to \code{\link[modi:MDmiss]{modi::MDmiss()}} to compute the Mahalanobis distance.
 
 Supports both single-group and multiple-group models.

--- a/tests/testthat/test-lavaan_rerun_multi_select_by_md.R
+++ b/tests/testthat/test-lavaan_rerun_multi_select_by_md.R
@@ -1,5 +1,4 @@
 skip_if_not_installed("modi")
-skip_if_not_installed("norm2")
 library(testthat)
 library(lavaan)
 

--- a/tests/testthat/test-lavaan_rerun_single_select_by_md.R
+++ b/tests/testthat/test-lavaan_rerun_single_select_by_md.R
@@ -1,5 +1,4 @@
 skip_if_not_installed("modi")
-skip_if_not_installed("norm2")
 library(testthat)
 library(lavaan)
 

--- a/tests/testthat/test-mahalanobis_exo_multi_missing.R
+++ b/tests/testthat/test-mahalanobis_exo_multi_missing.R
@@ -1,5 +1,4 @@
 skip_if_not_installed("modi")
-skip_if_not_installed("norm2")
 library(testthat)
 library(lavaan)
 library(semfindr)
@@ -30,11 +29,19 @@ head(fit0_data)
 exo_vars <- c("iv1", "iv2")
 fit0_data_exo <- dat0[, exo_vars]
 fit0_data_exo_g <- split(fit0_data_exo, dat0$gp)
+em_tmp <- function(x) {
+    suppressWarnings(em_out_fit <- lavaan::lavCor(x,
+                                                  missing = "fiml",
+                                                  output = "fit"))
+    em_out <- list(param = list())
+    tmp <- lavaan::lavInspect(em_out_fit, "implied")
+    em_out$param$beta <- tmp$mean
+    em_out$param$sigma <- tmp$cov
+    em_out
+  }
 md_predictors_check0 <- lapply(fit0_data_exo_g,
                           function(x) {
-                              em_out <- norm2::emNorm(x,
-                                                      estimate.worst = FALSE,
-                                                      criterion = 1e-6)
+                              em_out <- em_tmp(x)
                               out <- modi::MDmiss(x,
                                                   em_out$param$beta,
                                                   em_out$param$sigma)

--- a/tests/testthat/test-mahalanobis_exo_single_missing.R
+++ b/tests/testthat/test-mahalanobis_exo_single_missing.R
@@ -1,5 +1,4 @@
 skip_if_not_installed("modi")
-skip_if_not_installed("norm2")
 library(testthat)
 library(lavaan)
 library(semfindr)
@@ -28,7 +27,14 @@ fit0_free <- lavInspect(fit0, "free")
 i <- apply(fit0_free$beta, 1, function(x) all(x == 0))
 exo_vars <- names(i)[i]
 fit0_data_exo <- dat0[, exo_vars]
-em_out <- norm2::emNorm(fit0_data_exo, estimate.worst = FALSE, criterion = 1e-6)
+suppressWarnings(em_out_fit <- lavaan::lavCor(fit0_data_exo,
+                                              missing = "fiml",
+                                              output = "fit"))
+em_out <- list(param = list())
+tmp <- lavaan::lavInspect(em_out_fit, "implied")
+em_out$param$beta <- tmp$mean
+em_out$param$sigma <- tmp$cov
+
 md_predictors_check <- modi::MDmiss(fit0_data_exo,
                       em_out$param$beta,
                       em_out$param$sigma)

--- a/tests/testthat/test-mahalanobis_multi_missing.R
+++ b/tests/testthat/test-mahalanobis_multi_missing.R
@@ -1,5 +1,4 @@
 skip_if_not_installed("modi")
-skip_if_not_installed("norm2")
 library(testthat)
 library(lavaan)
 
@@ -29,11 +28,25 @@ fit0_data_g2 <- fit0_data[fit0_data$gp == "gp1", -5]
 head(fit0_data_g1)
 head(fit0_data_g2)
 
-em_out_g1 <- norm2::emNorm(fit0_data_g1, estimate.worst = FALSE, criterion = 1e-6)
+suppressWarnings(em_out_fit <- lavaan::lavCor(fit0_data_g1,
+                                              missing = "fiml",
+                                              output = "fit"))
+em_out <- list(param = list())
+tmp <- lavaan::lavInspect(em_out_fit, "implied")
+em_out$param$beta <- tmp$mean
+em_out$param$sigma <- tmp$cov
+em_out_g1 <- em_out
 md_check_g1 <- modi::MDmiss(fit0_data_g1,
                           em_out_g1$param$beta,
                           em_out_g1$param$sigma)
-em_out_g2 <- norm2::emNorm(fit0_data_g2, estimate.worst = FALSE, criterion = 1e-6)
+suppressWarnings(em_out_fit <- lavaan::lavCor(fit0_data_g2,
+                                              missing = "fiml",
+                                              output = "fit"))
+em_out <- list(param = list())
+tmp <- lavaan::lavInspect(em_out_fit, "implied")
+em_out$param$beta <- tmp$mean
+em_out$param$sigma <- tmp$cov
+em_out_g2 <- em_out
 md_check_g2 <- modi::MDmiss(fit0_data_g2,
                           em_out_g2$param$beta,
                           em_out_g2$param$sigma)

--- a/tests/testthat/test-mahalanobis_multi_select_by_md.R
+++ b/tests/testthat/test-mahalanobis_multi_select_by_md.R
@@ -1,5 +1,4 @@
 skip_if_not_installed("modi")
-skip_if_not_installed("norm2")
 library(testthat)
 library(lavaan)
 

--- a/tests/testthat/test-mahalanobis_single_missing.R
+++ b/tests/testthat/test-mahalanobis_single_missing.R
@@ -1,5 +1,4 @@
 skip_if_not_installed("modi")
-skip_if_not_installed("norm2")
 library(testthat)
 library(lavaan)
 
@@ -23,7 +22,13 @@ fit0_data <- lavInspect(fit0, "data")
 colnames(fit0_data) <- lavNames(fit0)
 head(fit0_data)
 
-em_out <- norm2::emNorm(fit0_data, estimate.worst = FALSE, criterion = 1e-6)
+suppressWarnings(em_out_fit <- lavaan::lavCor(fit0_data,
+                                              missing = "fiml",
+                                              output = "fit"))
+em_out <- list(param = list())
+tmp <- lavaan::lavInspect(em_out_fit, "implied")
+em_out$param$beta <- tmp$mean
+em_out$param$sigma <- tmp$cov
 md_check <- modi::MDmiss(fit0_data,
                           em_out$param$beta,
                           em_out$param$sigma)

--- a/tests/testthat/test-mahalanobis_single_select_by_md.R
+++ b/tests/testthat/test-mahalanobis_single_select_by_md.R
@@ -1,5 +1,4 @@
 skip_if_not_installed("modi")
-skip_if_not_installed("norm2")
 library(testthat)
 library(lavaan)
 


### PR DESCRIPTION
Tests and checks passed.